### PR TITLE
Changed JDBC connection string

### DIFF
--- a/6-Conexión BBDD/Plantilla automática/bbdd.java
+++ b/6-Conexión BBDD/Plantilla automática/bbdd.java
@@ -30,11 +30,11 @@ public class bbdd {
 		s = s.toLowerCase();
 		
 		String URL;
-		
+
 		if(s.equals("centro")) {
-			URL = "jdbc:oracle:thin:@192.168.3.26:1521:xe";
+			URL = "jdbc:oracle:thin:@//192.168.3.26:1521/XEPDB2";
 		} else {
-			URL = "jdbc:oracle:thin:@oracle.ilerna.com:1521:xe";
+			URL = "jdbc:oracle:thin:@//oracle.ilerna.com:1521/XEPDB2";
 		}
 		
 		System.out.println("¿Usuario?");


### PR DESCRIPTION
La base de dades ja no utilitza SID sinó que fa servir Service Name, he modificat el format de l'URL de connexió i he posat el Service Name corresponent que fem servir (XEPDB2).